### PR TITLE
Do not pass in metadata for zod generation

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,9 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { Handler } from "./types.js";
 
-export const toOpenAPISchema = async (schema: StandardSchemaV1) => {
+export const toOpenAPISchema = async (
+  schema: StandardSchemaV1, metadata?: Record<string, unknown>
+) => {
   const vendor = schema["~standard"].vendor;
 
   let mod: Handler;
@@ -20,5 +22,5 @@ export const toOpenAPISchema = async (schema: StandardSchemaV1) => {
       );
   }
 
-  return await (await mod).generator(schema);
+  return await (await mod).generator(schema, metadata);
 };

--- a/packages/core/src/zod.ts
+++ b/packages/core/src/zod.ts
@@ -2,5 +2,6 @@ import type { GeneratorFn } from "./types.js";
 import { createSchema } from "zod-openapi";
 import type * as z from "zod";
 
-export const generator: GeneratorFn = (schema, metadata) =>
-  createSchema(schema as z.ZodType, metadata);
+// Fallback to use schemaType as input if metadata isn't provided
+export const generator: GeneratorFn = (schema, metadata) => 
+  createSchema(schema as z.ZodType, { schemaType: "input", ...metadata });


### PR DESCRIPTION
toOpenAPISchema does not pass metadata, causing errors when generating with zod-openapi and if the zod schema has a transform. Rather than getting rid of metadata completely, I decided to expose the arg in the function signature and pass it to the generator.

Now, to solve the same issue as https://github.com/rhinobase/hono-openapi/issues/3, I passed in `schemaType` as `input` for the default value unless the metadata overrides it.