### PR TITLE
Zod 4 support

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,13 +44,9 @@
   },
   "peerDependencies": {
     "@standard-community/standard-json": "^0.1.0",
-    "json-schema-walker": "^2.0.0",
-    "zod-openapi": "^4.0.0"
+    "json-schema-walker": "^2.0.0"
   },
   "peerDependenciesMeta": {
-    "zod-openapi": {
-      "optional": true
-    },
     "@standard-community/standard-json": {
       "optional": true
     },
@@ -66,7 +62,7 @@
     "openapi-types": "^12.1.3",
     "pkgroll": "^2.5.1",
     "valibot": "1.0.0-rc.4",
-    "zod": "^3.24.2"
+    "zod": "^3.25.41"
   },
   "packageManager": "pnpm@10.6.3+sha512.bb45e34d50a9a76e858a95837301bfb6bd6d35aea2c5d52094fa497a467c43f5c440103ce2511e9e0a2f89c3d6071baac3358fc68ac6fb75e2ceb3d2736065e6"
 }

--- a/packages/core/src/default.ts
+++ b/packages/core/src/default.ts
@@ -1,11 +1,10 @@
-import type { SchemaResult } from "zod-openapi";
 import convert from "./convertor.js";
 import type { GeneratorFn } from "./types.js";
 import { toJsonSchema } from "@standard-community/standard-json";
 
 export const generator: GeneratorFn = async (schema) => {
-  const jsonSchema = toJsonSchema(schema);
+  const jsonSchema = await toJsonSchema(schema);
   return {
     schema: await convert(jsonSchema),
-  } as unknown as SchemaResult;
+  } as Record<string, unknown>;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,15 +4,14 @@ import type { Handler } from "./types.js";
 export const toOpenAPISchema = async (schema: StandardSchemaV1) => {
   const vendor = schema["~standard"].vendor;
 
+  // keep this switch if any other libs are added
   let mod: Handler;
   switch (vendor) {
     case "arktype":
     case "effect":
     case "valibot":
-      mod = import("./default.js");
-      break;
     case "zod":
-      mod = import("./zod.js");
+      mod = import("./default.js");
       break;
     default:
       throw new Error(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,10 +1,9 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import type { SchemaResult } from "zod-openapi";
 
 export type GeneratorFn = (
   schema: StandardSchemaV1,
   metadata?: Record<string, unknown>,
-) => SchemaResult | Promise<SchemaResult>;
+) => Record<string, unknown> | Promise<Record<string, unknown>>;
 
 export type Handler = Promise<{
   generator: GeneratorFn;

--- a/packages/core/src/zod.ts
+++ b/packages/core/src/zod.ts
@@ -1,6 +1,0 @@
-import type { GeneratorFn } from "./types.js";
-import { createSchema } from "zod-openapi";
-import type * as z from "zod";
-
-export const generator: GeneratorFn = (schema, metadata) =>
-  createSchema(schema as z.ZodType, metadata);


### PR DESCRIPTION
This PR removes the `zod-openapi` dependency and migrates to Zod 4's JSON schema handling. Please see the related standard-json PR for more info: https://github.com/standard-community/standard-json/pull/5

Works with hono-openapi's v0.5 branch