### PR TITLE
feat: move openapi-types and @standard-schema/spec to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,15 +57,17 @@
   },
   "peerDependencies": {
     "@standard-community/standard-json": "^0.3.5",
-    "@standard-schema/spec": "^1.0.0",
     "arktype": "^2.1.20",
     "effect": "^3.17.14",
-    "openapi-types": "^12.1.3",
     "sury": "^10.0.0",
     "typebox": "^1.0.0",
     "valibot": "^1.1.0",
     "zod": "^3.25.0 || ^4.0.0",
     "zod-openapi": "^4"
+  },
+  "dependencies": {
+    "@standard-schema/spec": "^1.0.0",
+    "openapi-types": "^12.1.3"
   },
   "peerDependenciesMeta": {
     "arktype": {


### PR DESCRIPTION
Although I understand the reasoning, I feel that those should be declared as regular deps rather than peer-dependencies.

As I understood this is mostly type definitions... but I feel moving them to deps might help installation (peer-deps aren't installed by default with all package managers/configs/version, and it might make sense to keep them hoisted to @standard-community/standard-api if an application uses a different version (openapi-type v11 for example)

Consider this PR to be we a suggestion. Not a must have

PS: There's of course a risk with type only packages... when we have duplicate (pnpm dedupe, yarn deduplicate... might help). But it's the same with peerdeps 

