### PR TITLE
fix: preserve external $ref URLs instead of converting to local refs

### DIFF
--- a/src/vendors/convert.ts
+++ b/src/vendors/convert.ts
@@ -132,11 +132,20 @@ export function convertToOpenAPISchema(
       $ref: `#/components/schemas/${id}`,
     };
   } else if (_jsonSchema.$ref) {
-    // Happens in effect schemas — the referenced definitions were already
-    // hoisted from `$defs` above, so we only need to rewrite the pointer.
-    const { $ref } = _jsonSchema;
+    // The referenced definitions were already hoisted from `$defs` above.
+    const { $ref, ...rest } = _jsonSchema;
 
-    // Remove the '#/$defs/' prefix from Effect's internal references
+    // Preserve external URLs as-is.
+    const lowerRef = $ref.toLowerCase();
+    if (
+      lowerRef.startsWith("http://") ||
+      lowerRef.startsWith("https://") ||
+      $ref.startsWith("//")
+    ) {
+      return { ...rest, $ref };
+    }
+
+    // Convert internal refs (e.g. Effect's #/$defs/) to OpenAPI component refs
     const ref = $ref.split("/").pop();
 
     return {

--- a/src/vendors/convert.ts
+++ b/src/vendors/convert.ts
@@ -135,7 +135,7 @@ export function convertToOpenAPISchema(
     // The referenced definitions were already hoisted from `$defs` above.
     const { $ref, ...rest } = _jsonSchema;
 
-    // Preserve external URLs as-is.
+    // Preserve external URLs (http/https) and protocol-relative URLs as-is
     const lowerRef = $ref.toLowerCase();
     if (
       lowerRef.startsWith("http://") ||

--- a/tests/__snapshots__/zod_v4.test.ts.snap
+++ b/tests/__snapshots__/zod_v4.test.ts.snap
@@ -29,6 +29,25 @@ exports[`zod v4 > basic 1`] = `
 }
 `;
 
+exports[`zod v4 > preserves external $ref URLs 1`] = `
+{
+  "components": undefined,
+  "schema": {
+    "description": "Schema with external ref",
+    "properties": {
+      "model": {
+        "$ref": "https://models.dev/model-schema.json#/$defs/Model",
+        "type": "string",
+      },
+    },
+    "required": [
+      "model",
+    ],
+    "type": "object",
+  },
+}
+`;
+
 exports[`zod v4 > with metadata 1`] = `
 {
   "components": {

--- a/tests/zod_v4.test.ts
+++ b/tests/zod_v4.test.ts
@@ -30,4 +30,17 @@ describe("zod v4", () => {
     const specs = await toOpenAPISchema(schema);
     expect(specs).toMatchSnapshot();
   });
+
+  it("preserves external $ref URLs", async () => {
+    const schema = z
+      .object({
+        model: z.string().meta({
+          $ref: "https://models.dev/model-schema.json#/$defs/Model",
+        }),
+      })
+      .describe("Schema with external ref");
+
+    const specs = await toOpenAPISchema(schema);
+    expect(specs).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
External `$ref` URLs (http/https) are now preserved as-is instead of being converted to local `#/components/schemas/` references.

This allows schemas to reference external JSON Schema definitions for editor autocomplete while keeping the OpenAPI spec valid.

Example: `$ref: "https://models.dev/model-schema.json#/$defs/Model"` is now preserved instead of being converted to `$ref: "#/components/schemas/Model"`.

cc @MathurAditya724

Blocked PR: https://github.com/anomalyco/opencode/pull/12112