### PR TITLE
fix: lift leftover $defs/definitions into components.schemas

### DIFF
--- a/src/vendors/convert.ts
+++ b/src/vendors/convert.ts
@@ -96,6 +96,28 @@ export function convertToOpenAPISchema(
     }
   });
 
+  // Hoist any leftover `$defs`/`definitions` into the shared components and
+  // strip them from the node. Some vendors (e.g. Effect Schema) emit a
+  // top-level `$defs` map alongside a container schema (`array`, `object`,
+  // `anyOf`, ...) even after their inner `$ref`s have been rewritten to
+  // `#/components/schemas/*`. Without this, the definitions would stay
+  // duplicated inline on the returned schema while `components.schemas` never
+  // receives them.
+  //
+  // Existing components win over the lifted defs: when a schema is
+  // `ref`/`$id`-annotated the vendor already registered the real definition
+  // and only leaves a self-referential `{ $ref }` stub inside `$defs`.
+  if (_jsonSchema.$defs || _jsonSchema.definitions) {
+    context.components.schemas = {
+      ..._jsonSchema.definitions,
+      ..._jsonSchema.$defs,
+      ...context.components.schemas,
+    };
+
+    delete _jsonSchema.$defs;
+    delete _jsonSchema.definitions;
+  }
+
   // If a ref is provided, use it to create a $ref in the OpenAPI components
   if (_jsonSchema.ref || _jsonSchema.$id) {
     const { ref, $id, ...component } = _jsonSchema;
@@ -110,16 +132,13 @@ export function convertToOpenAPISchema(
       $ref: `#/components/schemas/${id}`,
     };
   } else if (_jsonSchema.$ref) {
-    // Happens in effect schemas
-    const { $ref, $defs } = _jsonSchema;
+    // Happens in effect schemas — the referenced definitions were already
+    // hoisted from `$defs` above, so we only need to rewrite the pointer.
+    const { $ref } = _jsonSchema;
 
     // Remove the '#/$defs/' prefix from Effect's internal references
     const ref = $ref.split("/").pop();
 
-    context.components.schemas = {
-      ...context.components.schemas,
-      ...$defs,
-    };
     return {
       $ref: `#/components/schemas/${ref}`,
     };

--- a/tests/effect.test.ts
+++ b/tests/effect.test.ts
@@ -40,4 +40,72 @@ describe("effect", () => {
     const specs = await toOpenAPISchema(schema);
     expect(specs).toMatchSnapshot();
   });
+
+  it("lifts $defs into components when the root schema is a container", async () => {
+    class Bar extends Schema.Class<Bar>("Bar")({
+      baz: Schema.Number,
+    }) {}
+
+    class Foo extends Schema.Class<Foo>("Foo")({
+      bar: Schema.optional(Bar),
+    }) {}
+
+    class Item extends Schema.Class<Item>("Item")({
+      foo: Foo,
+      id: Schema.String,
+    }) {}
+
+    const { schema, components } = await toOpenAPISchema(
+      Schema.Array(Item).pipe(Schema.standardSchemaV1),
+    );
+
+    // The root schema must reference components, not embed $defs inline
+    expect((schema as { $defs?: unknown }).$defs).toBeUndefined();
+    expect(schema).toEqual({
+      type: "array",
+      items: { $ref: "#/components/schemas/Item" },
+    });
+
+    // The definitions must be lifted into components.schemas as real schemas
+    expect(Object.keys(components?.schemas ?? {})).toEqual(
+      expect.arrayContaining(["Item", "Foo", "Bar"]),
+    );
+    expect(components?.schemas?.Item).toMatchObject({ type: "object" });
+    expect(
+      (components?.schemas?.Item as { properties: Record<string, unknown> })
+        .properties.foo,
+    ).toEqual({ $ref: "#/components/schemas/Foo" });
+  });
+
+  it("does not clobber ref-annotated components with $ref stubs", async () => {
+    // When schemas carry a `ref` annotation the converter registers the real
+    // definition under components AND leaves a self-referential `{ $ref }`
+    // stub inside the container's `$defs`. The real component must win.
+    class Bar extends Schema.Class<Bar>("Bar")(
+      { baz: Schema.Number },
+      { jsonSchema: { ref: "Bar" } },
+    ) {}
+
+    class Item extends Schema.Class<Item>("Item")(
+      { bar: Bar },
+      { jsonSchema: { ref: "Item" } },
+    ) {}
+
+    const { schema, components } = await toOpenAPISchema(
+      Schema.Array(Item).pipe(Schema.standardSchemaV1),
+    );
+
+    expect((schema as { $defs?: unknown }).$defs).toBeUndefined();
+    expect(components?.schemas?.Item).toMatchObject({ type: "object" });
+    expect(components?.schemas?.Bar).toMatchObject({
+      type: "object",
+      properties: { baz: { type: "number" } },
+    });
+    expect(
+      (components?.schemas?.Item as { $ref?: string }).$ref,
+    ).toBeUndefined();
+    expect(
+      (components?.schemas?.Bar as { $ref?: string }).$ref,
+    ).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Problem

`convertToOpenAPISchema` only hoisted `$defs` into `components.schemas` when the node **itself** was a `$ref`. When the root schema is a container (`array`/`object`/`anyOf`) — e.g. Effect's `Schema.Array(Item)` — it fell through to `return _jsonSchema` with `$defs` still attached, even though the inner `$ref`s had already been rewritten to `#/components/schemas/*`.

The result is a self-inconsistent output: refs point at `components.schemas`, but the definitions stay inline under the returned schema's `$defs` while `components.schemas` is empty.

This was surfaced downstream in [rhinobase/hono-openapi#227](https://github.com/rhinobase/hono-openapi/issues/227), where it was patched with a shim. This fixes the root cause for all consumers.

## Fix

Hoist `$defs`/`definitions` into `context.components.schemas` and strip them from the node, unconditionally (not just in the `$ref` branch).

Existing `components.schemas` **win** over the lifted defs: when a schema is `ref`/`$id`-annotated, the converter already registers the real definition under `components.schemas` and leaves only a self-referential `{ $ref }` stub inside `$defs` — the real definition must win. The now-redundant `$defs` merge in the `$ref` branch is removed.

## Tests

Added two cases to `tests/effect.test.ts`:
- container root (`Schema.Array(Item)`) lifts nested `$defs` into components, no inline `$defs` left
- `ref`-annotated schemas aren't clobbered by `$ref` stubs

All 18 tests pass; no existing snapshots changed.