### PR TITLE
ci: add craft release system

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,16 @@
+# Craft Release Configuration
+# https://craft.sentry.dev/configuration/
+
+minVersion: "2.21.1"
+
+versioning:
+  policy: manual
+
+changelog:
+  filePath: CHANGELOG.md
+  policy: auto
+
+targets:
+  - name: npm
+    access: public
+  - name: github

--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -1,0 +1,15 @@
+name: Changelog Preview
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  changelog-preview:
+    name: Preview Changelog
+    uses: getsentry/craft/.github/workflows/changelog-preview.yml@v2
+    secrets: inherit

--- a/.github/workflows/package-artifacts.yml
+++ b/.github/workflows/package-artifacts.yml
@@ -1,0 +1,39 @@
+name: Package Artifacts
+on:
+  push:
+    branches:
+      - "release/**"
+
+concurrency:
+  group: package-artifacts-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  pack:
+    runs-on: ubuntu-latest
+    name: Build & pack tarball
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Pack tarball
+        run: pnpm pack
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.sha }}
+          path: "*.tgz"
+          if-no-files-found: error

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,108 @@
+name: Publish
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  actions: read
+  contents: write
+  issues: write
+  id-token: write
+
+jobs:
+  publish:
+    if: >-
+      github.event.label.name == 'accepted' &&
+      github.event.issue.state == 'open'
+    runs-on: ubuntu-latest
+    name: Publish release
+    timeout-minutes: 15
+    steps:
+      - name: Generate GitHub App token
+        id: token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.CRAFT_APP_ID }}
+          private-key: ${{ secrets.CRAFT_APP_PRIVATE_KEY }}
+
+      - name: Parse version from issue title
+        id: release
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          set -euo pipefail
+          # Title: "publish: <owner>/<repo>@<version>"
+          version="${ISSUE_TITLE##*@}"
+          if [[ -z "$version" ]]; then
+            echo "::error::Could not parse version from title: $ISSUE_TITLE"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "branch=release/$version" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: release/${{ steps.release.outputs.version }}
+          token: ${{ steps.token.outputs.token }}
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Set git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Install Craft
+        run: |
+          CRAFT_URL=$(curl -fsSL https://api.github.com/repos/getsentry/craft/releases/latest \
+            | jq -r '.assets[] | select(.name == "craft") | .browser_download_url')
+          sudo curl -fsSL -o /usr/local/bin/craft "$CRAFT_URL"
+          sudo chmod +x /usr/local/bin/craft
+
+      - name: Wait for package artifacts on release branch
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          set -euo pipefail
+          branch="${{ steps.release.outputs.branch }}"
+          echo "Waiting for Package Artifacts on $branch..."
+          run_id=$(gh run list --workflow "Package Artifacts" --branch "$branch" \
+            --json databaseId --jq '.[0].databaseId')
+          if [[ -z "$run_id" || "$run_id" == "null" ]]; then
+            echo "::error::No Package Artifacts run found for branch $branch"
+            exit 1
+          fi
+          gh run watch "$run_id" --exit-status
+
+      - name: Publish with Craft
+        run: craft publish "${{ steps.release.outputs.version }}" --no-input --no-status-check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_API_TOKEN: ${{ steps.token.outputs.token }}
+
+      - name: Close issue on success
+        if: success()
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          gh issue close "${{ github.event.issue.number }}" \
+            --comment "Published **v${{ steps.release.outputs.version }}** successfully.
+          [Workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
+      - name: Handle failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          gh issue comment "${{ github.event.issue.number }}" \
+            --body "Publish failed. See [run logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          gh issue edit "${{ github.event.issue.number }}" --remove-label accepted

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,0 +1,30 @@
+name: Release preview
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.x
+          package-manager-cache: false
+
+      - name: Install PNPM
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Create release preview PR
+        run: pnpm exec pkg-pr-new publish "."

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -27,4 +27,4 @@ jobs:
         run: pnpm build
 
       - name: Create release preview PR
-        run: pnpm exec pkg-pr-new publish "."
+        run: pnpm dlx pkg-pr-new publish "."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Explicit version to release (e.g. 1.0.0)"
+        required: true
+        type: string
+      merge_target:
+        description: Target branch to merge into
+        required: false
+        default: "main"
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Prepare ${{ github.event.inputs.version }}
+    steps:
+      - name: Generate GitHub App token
+        id: token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.CRAFT_APP_ID }}
+          private-key: ${{ secrets.CRAFT_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.token.outputs.token }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Craft prepare
+        id: craft
+        uses: getsentry/craft@v2
+        with:
+          version: ${{ github.event.inputs.version }}
+          merge_target: ${{ github.event.inputs.merge_target }}
+          publish_repo: self
+        env:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Release prepared"
+            echo "- Version: \`${{ steps.craft.outputs.version || github.event.inputs.version }}\`"
+            echo "- Release branch: \`${{ steps.craft.outputs.branch }}\`"
+            echo "- Publish request: ${{ steps.craft.outputs.issue_url }}"
+            echo ""
+            echo "Add the **accepted** label to the publish issue to publish."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds the [getsentry/craft](https://github.com/getsentry/craft) release pipeline, mirroring the setup used in `hono-openapi`.

## Workflows
- **`.craft.yml`** — manual versioning, auto changelog, npm (public) + github targets
- **`release.yml`** — `workflow_dispatch` → `craft prepare`: cuts a `release/<version>` branch and opens a publish-request issue
- **`publish.yml`** — publishes when the request issue is labeled `accepted`
- **`package-artifacts.yml`** — builds & packs the tarball on `release/**` pushes (consumed by publish)
- **`release-preview.yml`** — `pkg-pr-new` continuous release previews on push/PR
- **`changelog-preview.yml`** — reuses craft's shared changelog-preview workflow

The existing `test.yml` is left untouched.

## Required configuration (out of band, before this can run)
- [ ] `CRAFT_APP_ID` repository/org **variable** and `CRAFT_APP_PRIVATE_KEY` **secret** (a GitHub App with contents+issues write, used to mint the release token)
- [ ] [pkg.pr.new](https://github.com/apps/pkg-pr-new) GitHub App installed on the repo/org (for `release-preview`)
- [ ] npm **trusted publishing** configured for `@standard-community/standard-openapi`

Workflow files are byte-identical to the CI-validated ones in `hono-openapi`.